### PR TITLE
Remove Setup Steps from Action

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -67,6 +67,28 @@ usage: |-
   - `https://github.com/organizations/YOUR-ORG/settings/actions`
   - `https://github.com/YOUR-ORG/YOUR-REPO/settings/actions`
 
+
+  ### Requirements
+
+  This GitHub Action requires a few tools to be installed first. Install these in your workflow as given below or however best suits as your requirements.
+
+  ```yaml
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: "1.20"
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+  ```
+
   ### Workflow example
 
   ```yaml

--- a/README.yaml
+++ b/README.yaml
@@ -186,3 +186,7 @@ contributors:
     github: "zdmytriv"
   - name: "Erik Osterman"
     github: "osterman"
+  - name: "Erik Osterman"
+    github: "osterman"
+  - name: "Daniel Miller"
+    github: "milldr"

--- a/action.yml
+++ b/action.yml
@@ -72,16 +72,6 @@ runs:
       with:
         atmos-version: ${{ inputs.atmos-version }}
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: "1.20"
-
-    - name: Setup Node
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16.x
-
     - name: Install Go Dependencies
       shell: bash
       run: |
@@ -89,11 +79,6 @@ runs:
         go mod download
         go install github.com/hashicorp/go-getter/cmd/go-getter
         echo "GO_GETTER_TOOL=$(go env GOPATH)/bin/go-getter" >> "$GITHUB_ENV"
-
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
 
     - name: Install Python Dependencies
       shell: bash


### PR DESCRIPTION
## what
- moved setup steps outside of action

## why
- The [python setup step](https://github.com/cloudposse/github-action-atmos-component-updater/blob/main/action.yml#L93-L96) does not support Amazon Linux: https://github.com/actions/setup-python/issues/460

## references
- https://github.com/actions/setup-python/issues/460