### PR TITLE
Avoid Opening New PRs for existing opened/closed PRs for particular branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Major Release Tagger
+name: Release
 
 on:
   release:
@@ -10,3 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: cloudposse/github-action-major-release-tagger@v1
+      - uses: cloudposse/github-action-release-branch-manager@v1

--- a/src/component_updater.py
+++ b/src/component_updater.py
@@ -29,7 +29,7 @@ class ComponentUpdaterResponseState(Enum):
     URI_IS_NOT_GIT_REPO = 5
     NO_LATEST_TAG_FOUND_IN_COMPONENT_REPO = 6
     ALREADY_UP_TO_DATE = 7
-    REMOTE_BRANCH_FOR_COMPONENT_UPDATER_ALREADY_EXIST = 8
+    REMOTE_BRANCH_FOR_COMPONENT_UPDATER_ALREADY_EXISTS = 8
     NO_CHANGES_FOUND = 9
     FAILED_TO_VENDOR_COMPONENT = 10
     MAX_PRS_REACHED = 11
@@ -173,7 +173,7 @@ class ComponentUpdater:
 
         if self.__github_provider.branch_exists(branch_name):
             logging.warning(f"Branch '{branch_name}' already exists. Skipping")
-            response.state = ComponentUpdaterResponseState.REMOTE_BRANCH_FOR_COMPONENT_UPDATER_ALREADY_EXIST
+            response.state = ComponentUpdaterResponseState.REMOTE_BRANCH_FOR_COMPONENT_UPDATER_ALREADY_EXISTS
             return response
 
         if self.__github_provider.pr_for_branch_exists(branch_name):

--- a/src/component_updater.py
+++ b/src/component_updater.py
@@ -33,6 +33,7 @@ class ComponentUpdaterResponseState(Enum):
     NO_CHANGES_FOUND = 9
     FAILED_TO_VENDOR_COMPONENT = 10
     MAX_PRS_REACHED = 11
+    PR_FOR_BRANCH_ALREADY_EXISTS = 12
 
 
 class ComponentUpdaterResponse:
@@ -168,9 +169,14 @@ class ComponentUpdater:
 
         response.branch_name = branch_name
 
-        if self.__github_provider.branch_exists(updated_component.infra_repo_dir, branch_name):
+        if self.__github_provider.branch_exists(branch_name):
             logging.warning(f"Branch '{branch_name}' already exists. Skipping")
             response.state = ComponentUpdaterResponseState.REMOTE_BRANCH_FOR_COMPONENT_UPDATER_ALREADY_EXIST
+            return response
+
+        if self.__github_provider.pr_for_branch_exists(branch_name):
+            logging.warning(f"PR for branch '{branch_name}' already exists. Skipping")
+            response.state = ComponentUpdaterResponseState.PR_FOR_BRANCH_ALREADY_EXISTS
             return response
 
         updated_component.update_version(latest_tag)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -52,7 +52,7 @@ class GitHubProvider:
     def build_branch_to_pr_map(self):
         branch_to_pr_map = {}
 
-        for pull_request in self.__repo.get_pulls():
+        for pull_request in self.__repo.get_pulls(state='all'):
             logging.info(f"Found PR: {pull_request.title} for branch {pull_request.head.ref}")
             branch_to_pr_map[pull_request.head] = pull_request
 

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -53,7 +53,7 @@ class GitHubProvider:
         branch_to_pr_map = {}
 
         for pull_request in self.__repo.get_pulls(state='all'):
-            logging.info(f"Found PR: '{pull_request.title}' for branch '{pull_request.head.ref}'")
+            logging.debug(f"Found PR: '{pull_request.title}' for branch '{pull_request.head.ref}'")
             branch_to_pr_map[pull_request.head.ref] = pull_request
 
         return branch_to_pr_map
@@ -69,13 +69,13 @@ class GitHubProvider:
             repo = git.repo.Repo(repo_dir)
 
             for branch in repo.heads:
-                logging.info(f"Found local branch: {branch.name}")
+                logging.debug(f"Found branch: {branch.name}")
                 branches.append(branch.name)
 
             remote_branches = repo.remote().refs
 
             for branch in remote_branches:
-                logging.info(f"Found remote branch: {branch.name}")
+                logging.debug(f"Found branch: {branch.name}")
                 branches.append(branch.name)
         except Exception as exception:  # pylint: disable=broad-exception-caught
             logging.error(str(exception))

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -53,7 +53,7 @@ class GitHubProvider:
         branch_to_pr_map = {}
 
         for pull_request in self.__repo.get_pulls():
-            logging.info(f"Found PR: {pull_request.title} for branch {pull_request.head}")
+            logging.info(f"Found PR: {pull_request.title} for branch {pull_request.head.ref}")
             branch_to_pr_map[pull_request.head] = pull_request
 
         return branch_to_pr_map

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -53,8 +53,8 @@ class GitHubProvider:
         branch_to_pr_map = {}
 
         for pull_request in self.__repo.get_pulls(state='all'):
-            logging.info(f"Found PR: {pull_request.title} for branch {pull_request.head.ref}")
-            branch_to_pr_map[pull_request.head] = pull_request
+            logging.info(f"Found PR: '{pull_request.title}' for branch '{pull_request.head.ref}'")
+            branch_to_pr_map[pull_request.head.ref] = pull_request
 
         return branch_to_pr_map
 

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from config import Config
 
 
 def main(github_api_token: str, config: Config):
-    github_provider = GitHubProvider(config, Github(github_api_token))
+    github_provider = GitHubProvider(config, Github(github_api_token, per_page=100, retry=3))
     tools_manager = ToolsManager(config.go_getter_tool)
 
     component_updater = ComponentUpdater(github_provider, tools_manager, config.infra_terraform_dirs, config)

--- a/src/tests/fake_tools_manager.py
+++ b/src/tests/fake_tools_manager.py
@@ -15,7 +15,7 @@ class FakeToolsManager(ToolsManager):
         self.is_valid_git_repo: bool = is_valid_git_repo
 
     def atmos_vendor_component(self, component: AtmosComponent):
-        logging.debug(f"Vendoring component: {component}")
+        logging.debug(f"Vendoring component:\n{component}")
 
         source_file = os.path.join(os.getcwd(), TERRAFORM_COMPONENTS_REPO_PATH, str(component.version), 'modules', component.name)
 

--- a/src/tests/test_component_updater.py
+++ b/src/tests/test_component_updater.py
@@ -154,7 +154,7 @@ def test_components_remote_branch_exists(config: Config):
 
     # validate
     assert len(responses) == 1
-    assert responses[0].state == ComponentUpdaterResponseState.REMOTE_BRANCH_FOR_COMPONENT_UPDATER_ALREADY_EXIST
+    assert responses[0].state == ComponentUpdaterResponseState.REMOTE_BRANCH_FOR_COMPONENT_UPDATER_ALREADY_EXISTS
 
 
 def test_components_pr_exists(config: Config):

--- a/src/tests/test_component_updater.py
+++ b/src/tests/test_component_updater.py
@@ -60,6 +60,7 @@ def prep_github_provider(config: Config):
     fake_github = mock.MagicMock()
     fake_github_provider = GitHubProvider(config, fake_github)
     fake_github_provider.branch_exists = mock.MagicMock(return_value=False)
+    fake_github_provider.pr_for_branch_exists = mock.MagicMock(return_value=False)
     fake_github_provider.create_branch_and_push_all_changes = mock.MagicMock()
     return fake_github_provider
 
@@ -156,6 +157,23 @@ def test_components_remote_branch_exists(config: Config):
     assert responses[0].state == ComponentUpdaterResponseState.REMOTE_BRANCH_FOR_COMPONENT_UPDATER_ALREADY_EXIST
 
 
+def test_components_pr_exists(config: Config):
+    # setup
+    prepare_infra_repo(config.infra_repo_dir)
+    create_component(config.infra_repo_dir, 'test_component_01', TAG_1)
+
+    fake_github_provider = prep_github_provider(config)
+    fake_github_provider.pr_for_branch_exists = mock.MagicMock(return_value=True)
+    component_updater = ComponentUpdater(fake_github_provider, FakeToolsManager(TAG_3), config.infra_terraform_dirs, config)
+
+    # test
+    responses = component_updater.update()
+
+    # validate
+    assert len(responses) == 1
+    assert responses[0].state == ComponentUpdaterResponseState.PR_FOR_BRANCH_ALREADY_EXISTS
+
+
 def test_not_vendored_component_with_not_skip_vendoring(config: Config):
     # setup
     prepare_infra_repo(config.infra_repo_dir)
@@ -195,7 +213,7 @@ def test_not_vendored_component_with_skip_vendoring(config: Config):
 
     response = responses[0]
 
-    assert response.state == ComponentUpdaterResponseState.UPDATED
+    assert response.state == ComponentUpdaterResponseState.COMPONENT_NOT_VENDORED
 
     # checking that component was vendored
     assert not os.path.exists(os.path.join(response.component.infra_repo_dir, TERRAFORM_DIR, response.component.name, 'main.tf'))
@@ -261,7 +279,6 @@ def test_multiple_components_updated(config: Config):
 
 def test_some_components_updated(config: Config):
     # setup
-    config.skip_component_vendoring = True
     prepare_infra_repo(config.infra_repo_dir)
     create_component(config.infra_repo_dir, 'test_component_01', TAG_1)
     create_component(config.infra_repo_dir, 'test_component_02', TAG_1)
@@ -275,6 +292,26 @@ def test_some_components_updated(config: Config):
     assert len(responses) == 2
     assert responses[0].state == ComponentUpdaterResponseState.NO_CHANGES_FOUND
     assert responses[1].state == ComponentUpdaterResponseState.UPDATED
+
+
+def test_some_vendored_and_some_not(config: Config):
+    # setup
+    config.skip_component_vendoring = True
+    prepare_infra_repo(config.infra_repo_dir)
+    create_component(config.infra_repo_dir, 'test_component_01', TAG_1)
+    create_component(config.infra_repo_dir, 'test_component_02', TAG_1)
+    shutil.copyfile(os.path.join(os.getcwd(), 'src/tests/fixtures/terraform-aws-components/', TAG_1, 'modules/test_component_01/main.tf'),
+                    os.path.join(config.infra_repo_dir, TERRAFORM_DIR, 'test_component_01', 'main.tf'))
+
+    component_updater = ComponentUpdater(prep_github_provider(config), FakeToolsManager(TAG_2), config.infra_terraform_dirs, config)
+
+    # test
+    responses = component_updater.update()
+
+    # validate
+    assert len(responses) == 2
+    assert responses[0].state == ComponentUpdaterResponseState.NO_CHANGES_FOUND
+    assert responses[1].state == ComponentUpdaterResponseState.COMPONENT_NOT_VENDORED
 
 
 def test_missing_component(config: Config):


### PR DESCRIPTION
## what
* Do not open new PR if PR for a specific branch has already been opened or closed
* Cache branches and PRs on start. This suppose to speed up the processing
* Skip component processing if the component was not pulled and `skip_vendoring=true`
* Added "release branch manager" GHA to release new branches on a major release

## why
* Made updater to be aware of existing opened/closed PRs for particular branch 

## references
