### PR TITLE
Pin base docker image to ubuntu:jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 ARG ATMOS_VERSION=1.34.2
 ARG GO_VERSION=1.20


### PR DESCRIPTION
## what
* Pin base docker image to `ubuntu:jammy`

## why
* Docker build failed for ubuntu version `>= 22.04`

## references
* https://github.com/cloudposse/github-action-atmos-component-updater/actions/runs/9009606808/job/24754152180
* DEV-2147 `github-action-atmos-component-updater` is broken for every customer