### PR TITLE
Add GPG Key ID (#39)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: "Skip creation of remote branches and pull requests. Only print list of affected componented into file that is defined in 'outputs.affected-components-file'"
     required: false
     default: 'false'
+  gpg-key-id:
+    description: "GPG key ID to sign commits. Default ''"
+    required: false
+    default: ''
   pr-labels:
     description: "Comma or new line separated list of labels that will added on PR creation. Default: `component-update`"
     required: false
@@ -70,6 +74,7 @@ runs:
     EXCLUDE: ${{ inputs.exclude }}
     LOG_LEVEL: ${{ inputs.log-level }}
     DRY_RUN: ${{ inputs.dry-run }}
+    GPG_KEY_ID: ${{ inputs.GPG_KEY_ID }}
     PR_LABELS: ${{ inputs.pr-labels }}
     PR_TITLE_TEMPLATE: ${{ inputs.pr-title-template }}
     PR_BODY_TEMPLATE: ${{ inputs.pr-body-template }}

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
     EXCLUDE: ${{ inputs.exclude }}
     LOG_LEVEL: ${{ inputs.log-level }}
     DRY_RUN: ${{ inputs.dry-run }}
-    GPG_KEY_ID: ${{ inputs.GPG_KEY_ID }}
+    GPG_KEY_ID: ${{ inputs.gpg-key-id }}
     PR_LABELS: ${{ inputs.pr-labels }}
     PR_TITLE_TEMPLATE: ${{ inputs.pr-title-template }}
     PR_BODY_TEMPLATE: ${{ inputs.pr-body-template }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ python3 src/main.py \
     --exclude "${EXCLUDE}" \
     --log-level ${LOG_LEVEL} \
     --dry-run ${DRY_RUN} \
+    --gpg-key-id "${GPG_KEY_ID}" \
     --pr-labels "${PR_LABELS}" \
     --pr-title-template "${PR_TITLE_TEMPLATE}" \
     --pr-body-template "${PR_BODY_TEMPLATE}" \

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ class Config:
                  go_getter_tool: str,
                  dry_run: bool,
                  affected_components_file: str = '',
+                 gpg_key_id: str = '',
                  pr_title_template: str = '',
                  pr_body_template: str = '',
                  pr_labels: str = 'component-update'):
@@ -30,6 +31,7 @@ class Config:
         self.dry_run: bool = dry_run
         self.components_download_dir: str = io.create_tmp_dir()
         self.skip_component_repo_fetching: bool = False
+        self.gpg_key_id: str = gpg_key_id
         self.pr_title_template: str = pr_title_template
         self.pr_body_template: str = pr_body_template
         self.pr_labels: List[str] = utils.parse_comma_or_new_line_separated_list(pr_labels)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -89,7 +89,11 @@ class GitHubProvider:
 
         repo.git.checkout(new_branch)
         repo.git.add("-A")
-        repo.index.commit(commit_message)
+
+        if self.__config.gpg_key_id:
+            repo.index.commit(commit_message, gpg_sign=True, gpg_signing_key=self.__config.gpg_key_id)
+        else:
+            repo.index.commit(commit_message)
 
         if not self.__config.dry_run:
             repo.git.push("--set-upstream", "origin", branch_name)

--- a/src/main.py
+++ b/src/main.py
@@ -69,6 +69,11 @@ def main(github_api_token: str, config: Config):
               show_default=True,
               default="affected_components.json",
               help="Path to output file that will contain list of affected components in json format")
+@click.option('--gpg-key-id',
+              required=False,
+              show_default=True,
+              default="",
+              help="GPG key ID to sign commits")
 @click.option('--pr-title-template',
               required=False,
               show_default=True,
@@ -96,6 +101,7 @@ def cli_main(github_api_token,
              log_level,
              dry_run,
              affected_components_file,
+             gpg_key_id,
              pr_title_template,
              pr_body_template,
              pr_labels):
@@ -113,6 +119,7 @@ def cli_main(github_api_token,
                     go_getter_tool,
                     dry_run,
                     affected_components_file,
+                    gpg_key_id,
                     pr_title_template,
                     pr_body_template,
                     pr_labels)


### PR DESCRIPTION
## what

> [!IMPORTANT]
> This pull request is a work in progress as I would love to see this feature but do not want to encroach on any work from the CloudPosse team. If this PR is not on the right track, feel free to close at your will

## why

- Provides an interface for teams to sign component updater commits
- The following is an example of how this could be leveraged to sign component updater commits:

```yaml
name: "atmos-components"

on:
  workflow_dispatch: {}

  schedule:
    - cron:  '0 8 * * 1'         # Execute every week on Monday at 08:00

permissions:
  contents: write
  pull-requests: write

jobs:
  update:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v3
        with:
          fetch-depth: 0

      - name: Import GPG Key
        run: |
          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
          git config --global user.signingkey ${{ secrets.GPG_KEY_ID }}
          git config --global commit.gpgSign true

      - name: Update Atmos Components
        uses: cloudposse/github-action-atmos-component-updater@v2
        with:
          github-access-token: ${{ secrets.GITHUB_TOKEN }}
          max-number-of-prs: 5
          include: |
            aws-*
            eks/*
            bastion
          exclude: aws-sso,aws-saml
        env:
          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
```




https://github.com/cloudposse/github-action-atmos-component-updater/pull/39