### PR TITLE
fix: fix gpg signing using git-plumbing method

### DIFF
--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -91,7 +91,7 @@ class GitHubProvider:
         repo.git.add("-A")
 
         if self.__config.gpg_key_id:
-            repo.index.commit('-S', f'--gpg-sign={self.__config.gpg_key_id}', '-m', commit_message)
+            repo.git.commit('-S', f'--gpg-sign={self.__config.gpg_key_id}', '-m', commit_message)
         else:
             repo.index.commit(commit_message)
 


### PR DESCRIPTION
## what

- GitPython does not allow you to sign commits with its `git-porcelain` method. Previously, this method was used but resulted in an error during execution. This change utilizes `git-plumbing` method to accomplish signed commits

## why

- GitPython does not allow you to sign commits with its `git-porcelain` method. The way you typically commit with GitPython is:

```python
repo = Repo(repo_dir)
index = repo.index
index.add([file_to_commit_path])
author = Actor("An author", "rosesecurity@pythonisnotmyfavorite.com")

index.commit("my commit message", author=author)
```

- `index.commit` method does not provide any argument to sign commits. If you want to sign commits you have to use the the `git-plumbing` method `git.commit(...)`:

```py
signingkey = "<KEY_ID>"

repo = Repo.init('.')
# Make changes
update_file = "./testing.txt"
with open(update_file, "a") as f:
    f.write("\nfix gpg signing")

# Add to stage
repo.index.add([update_file])

# Commit
repo.git.commit('-S', f'--gpg-sign={signingkey}', '-m', "my commit message")
```

The result:

```console
# Grab commit SHA
 ❯ git log

# Verify commit is signed
 ❯ git verify-commit a9d6677
gpg: Signature made Wed Sep 11 18:16:36 2024 CDT
gpg:                using EDDSA key <KEY>
gpg: Good signature from "RoseSecurity (MacBook Pro) <rosesecurity@pythonisnotmyfavorite.com>" [ultimate]
```

## references

- [Signing Commits with GitPython](https://github.com/nautilus-cyberneering/pygithub/blob/main/docs/how_to_sign_commits_using_the_gitpython_package.md)