### PR TITLE
Automatically Sign Commits Using GitHub API Instead of GitPython and GPG

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,6 @@ class Config:
                  go_getter_tool: str,
                  dry_run: bool,
                  affected_components_file: str = '',
-                 gpg_key_id: str = '',
                  pr_title_template: str = '',
                  pr_body_template: str = '',
                  pr_labels: str = 'component-update'):
@@ -31,7 +30,6 @@ class Config:
         self.dry_run: bool = dry_run
         self.components_download_dir: str = io.create_tmp_dir()
         self.skip_component_repo_fetching: bool = False
-        self.gpg_key_id: str = gpg_key_id
         self.pr_title_template: str = pr_title_template
         self.pr_body_template: str = pr_body_template
         self.pr_labels: List[str] = utils.parse_comma_or_new_line_separated_list(pr_labels)

--- a/src/main.py
+++ b/src/main.py
@@ -69,11 +69,6 @@ def main(github_api_token: str, config: Config):
               show_default=True,
               default="affected_components.json",
               help="Path to output file that will contain list of affected components in json format")
-@click.option('--gpg-key-id',
-              required=False,
-              show_default=True,
-              default="",
-              help="GPG key ID to sign commits")
 @click.option('--pr-title-template',
               required=False,
               show_default=True,
@@ -101,7 +96,6 @@ def cli_main(github_api_token,
              log_level,
              dry_run,
              affected_components_file,
-             gpg_key_id,
              pr_title_template,
              pr_body_template,
              pr_labels):
@@ -119,7 +113,6 @@ def cli_main(github_api_token,
                     go_getter_tool,
                     dry_run,
                     affected_components_file,
-                    gpg_key_id,
                     pr_title_template,
                     pr_body_template,
                     pr_labels)


### PR DESCRIPTION
## what

> [!CAUTION]
> This change has only undergone local development and has not been adequately tested for merge

- Removes GPG signing key option
- Updates commit signing to use `PyGitHub` instead of `GitPython` library

## why

- Commits are made using `GitPython`, while pull requests are handled with `PyGitHub`. I found that PyGitHub can also make commits, and it could leverage the Atmos App token to automatically sign them. Let me know if you'd be interested in testing this approach

## references

- [Commit Signing](https://github.com/nautilus-cyberneering/pygithub/blob/main/docs/how_to_sign_automatic_commits_in_github_actions.md)
