### PR TITLE
Automatically Sign Commits Using GitHub API Instead of GitPython and GPG

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,10 +41,6 @@ inputs:
     description: "Skip creation of remote branches and pull requests. Only print list of affected componented into file that is defined in 'outputs.affected-components-file'"
     required: false
     default: 'false'
-  gpg-key-id:
-    description: "GPG key ID to sign commits. Default ''"
-    required: false
-    default: ''
   pr-labels:
     description: "Comma or new line separated list of labels that will added on PR creation. Default: `component-update`"
     required: false
@@ -74,7 +70,6 @@ runs:
     EXCLUDE: ${{ inputs.exclude }}
     LOG_LEVEL: ${{ inputs.log-level }}
     DRY_RUN: ${{ inputs.dry-run }}
-    GPG_KEY_ID: ${{ inputs.gpg-key-id }}
     PR_LABELS: ${{ inputs.pr-labels }}
     PR_TITLE_TEMPLATE: ${{ inputs.pr-title-template }}
     PR_BODY_TEMPLATE: ${{ inputs.pr-body-template }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,6 @@ python3 src/main.py \
     --exclude "${EXCLUDE}" \
     --log-level ${LOG_LEVEL} \
     --dry-run ${DRY_RUN} \
-    --gpg-key-id "${GPG_KEY_ID}" \
     --pr-labels "${PR_LABELS}" \
     --pr-title-template "${PR_TITLE_TEMPLATE}" \
     --pr-body-template "${PR_BODY_TEMPLATE}" \

--- a/src/component_updater.py
+++ b/src/component_updater.py
@@ -275,7 +275,7 @@ class ComponentUpdater:
         return needs_update
 
     def __create_branch_and_pr(self, repo_dir, original_component: AtmosComponent, updated_component: AtmosComponent, branch_name: str) -> PullRequestCreationResponse:
-        self.__github_provider.create_branch_and_push_all_changes(branch_name,
+        self.__github_provider.create_branch_and_push_all_changes(repo_dir, branch_name,
                                                                   COMMIT_MESSAGE_TEMPLATE.format(
                                                                       component_name=updated_component.name,
                                                                       component_version=updated_component.version))

--- a/src/component_updater.py
+++ b/src/component_updater.py
@@ -275,8 +275,7 @@ class ComponentUpdater:
         return needs_update
 
     def __create_branch_and_pr(self, repo_dir, original_component: AtmosComponent, updated_component: AtmosComponent, branch_name: str) -> PullRequestCreationResponse:
-        self.__github_provider.create_branch_and_push_all_changes(repo_dir,
-                                                                  branch_name,
+        self.__github_provider.create_branch_and_push_all_changes(branch_name,
                                                                   COMMIT_MESSAGE_TEMPLATE.format(
                                                                       component_name=updated_component.name,
                                                                       component_version=updated_component.version))

--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,6 @@ class Config:
                  go_getter_tool: str,
                  dry_run: bool,
                  affected_components_file: str = '',
-                 gpg_key_id: str = '',
                  pr_title_template: str = '',
                  pr_body_template: str = '',
                  pr_labels: str = 'component-update'):
@@ -31,7 +30,6 @@ class Config:
         self.dry_run: bool = dry_run
         self.components_download_dir: str = io.create_tmp_dir()
         self.skip_component_repo_fetching: bool = False
-        self.gpg_key_id: str = gpg_key_id
         self.pr_title_template: str = pr_title_template
         self.pr_body_template: str = pr_body_template
         self.pr_labels: List[str] = utils.parse_comma_or_new_line_separated_list(pr_labels)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -94,12 +94,13 @@ class GitHubProvider:
         print("=======================================================================================================")
         for d in diffs:
             with open(d.a_path, "r") as f:
-                blob = self.__repo.create_git_blob(f.read(), "utf-8")
+                content = f.read()
+                blob = self.__repo.create_git_blob(content, "utf-8")
                 tree_elements.append(InputGitTreeElement(
                     path=d.a_path,
                     mode='100644',
                     type='blob',
-                    content=blob.content,
+                    content=content,
                     sha=blob.sha
                 ))
             print(d.a_path)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -100,8 +100,7 @@ class GitHubProvider:
                     path=d.a_path,
                     mode='100644',
                     type='blob',
-                    content=content,
-                    sha=blob.sha
+                    content=content
                 ))
             print(d.a_path)
         print("=======================================================================================================")

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -105,8 +105,6 @@ class GitHubProvider:
         print("=======================================================================================================")
         # repo_dir
 
-        ref = self.__repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=base_branch.commit.sha)
-
         new_tree = self.__repo.create_git_tree(tree_elements, base_tree)
         commit = self.__repo.create_git_commit(
             message=commit_message,
@@ -114,7 +112,7 @@ class GitHubProvider:
             parents=[parent_commit]
         )
 
-        self.__repo.update_git_ref(ref=f"heads/{branch_name}", sha=commit.sha)
+        self.__repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=commit.sha)
 
         if not self.__config.dry_run:
             logging.info(f"Changes pushed to branch {branch_name}")

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -87,15 +87,16 @@ class GitHubProvider:
         base_tree = self.__repo.get_git_tree(base_branch.commit.sha)
 
         repo = git.repo.Repo(repo_dir)
-        diff = repo.git.diff('HEAD')
+        diffs = repo.index.diff(None)
         print("=======================================================================================================")
-        print(diff)
+        for d in diffs:
+            print(d.a_path)
         print("=======================================================================================================")
         # repo_dir
 
         ref = self.__repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=base_branch.commit.sha)
 
-        new_tree = self.__repo.create_git_tree([], base_tree.sha)
+        new_tree = self.__repo.create_git_tree([], base_tree)
         commit = self.__repo.create_git_commit(
             message=commit_message,
             tree=new_tree.sha,

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -99,12 +99,9 @@ class GitHubProvider:
             import os
             with open(os.path.join(repo_dir, d.b_path), "r") as f:
                 content = f.read()
-                print("====================================")
-                print(str(oct(d.b_mode))[2:])
-                print("====================================")
                 item = InputGitTreeElement(
                     path=d.b_path,
-                    mode=str(d.b_mode),
+                    mode=str(oct(d.b_mode))[2:],
                     type='commit',
                     content=content
                 )

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -95,6 +95,7 @@ class GitHubProvider:
         for d in diffs:
             with open(d.a_path, "r") as f:
                 content = f.read()
+                print(d.a_path)
                 print(content)
                 # blob = self.__repo.create_git_blob(content, "utf-8")
                 item = InputGitTreeElement(
@@ -104,10 +105,8 @@ class GitHubProvider:
                     content=content
                 )
                 tree_elements.append(item)
-        print(tree_elements)
         print("=======================================================================================================")
         # repo_dir
-
         new_tree = self.__repo.create_git_tree(tree_elements, base_tree)
         commit = self.__repo.create_git_commit(
             message=commit_message,

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -94,12 +94,7 @@ class GitHubProvider:
         print("=======================================================================================================")
         for d in diffs:
             with open(d.a_path, "r") as f:
-                import datetime
-                now = datetime.datetime.now()
-                content = str(now)
-                print(d.a_path)
-                print(content)
-                # blob = self.__repo.create_git_blob(content, "utf-8")
+                content = f.read()
                 item = InputGitTreeElement(
                     path=d.a_path,
                     mode='100644',

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -86,6 +86,8 @@ class GitHubProvider:
         base_branch = self.__repo.get_branch(self.__repo.default_branch)
         base_tree = self.__repo.get_git_tree(base_branch.commit.sha)
 
+        parent_commit = self.__repo.get_git_commit(base_branch.commit.sha)
+
         repo = git.repo.Repo(repo_dir)
         diffs = repo.index.diff(None)
         tree_elements = []
@@ -109,7 +111,7 @@ class GitHubProvider:
         commit = self.__repo.create_git_commit(
             message=commit_message,
             tree=new_tree,
-            parents=[base_branch.commit.sha]
+            parents=[parent_commit]
         )
 
         self.__repo.update_git_ref(ref=f"heads/{branch_name}", sha=commit.sha)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -96,13 +96,14 @@ class GitHubProvider:
             with open(d.a_path, "r") as f:
                 content = f.read()
                 print(content)
-                blob = self.__repo.create_git_blob(content, "utf-8")
-                tree_elements.append(InputGitTreeElement(
+                # blob = self.__repo.create_git_blob(content, "utf-8")
+                item = InputGitTreeElement(
                     path=d.a_path,
                     mode='100644',
                     type='blob',
-                    sha=blob.sha
-                ))
+                    content=content
+                )
+                tree_elements.append(item)
         print(tree_elements)
         print("=======================================================================================================")
         # repo_dir

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -94,7 +94,9 @@ class GitHubProvider:
         print("=======================================================================================================")
         for d in diffs:
             with open(d.a_path, "r") as f:
-                content = f.read()
+                import datetime
+                now = datetime.datetime.now()
+                content = str(now)
                 print(d.a_path)
                 print(content)
                 # blob = self.__repo.create_git_blob(content, "utf-8")

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -100,7 +100,7 @@ class GitHubProvider:
             with open(os.path.join(repo_dir, d.b_path), "r") as f:
                 content = f.read()
                 print("====================================")
-                print(str(d.b_mode))
+                print(str(oct(d.b_mode)))
                 print("====================================")
                 item = InputGitTreeElement(
                     path=d.b_path,

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -99,6 +99,9 @@ class GitHubProvider:
             import os
             with open(os.path.join(repo_dir, d.b_path), "r") as f:
                 content = f.read()
+                print("====================================")
+                print(str(d.b_mode))
+                print("====================================")
                 item = InputGitTreeElement(
                     path=d.b_path,
                     mode=str(d.b_mode),

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -108,7 +108,7 @@ class GitHubProvider:
         new_tree = self.__repo.create_git_tree(tree_elements, base_tree)
         commit = self.__repo.create_git_commit(
             message=commit_message,
-            tree=new_tree.sha,
+            tree=new_tree,
             parents=[base_branch.commit.sha]
         )
 

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -91,13 +91,14 @@ class GitHubProvider:
         tree_elements = []
         print("=======================================================================================================")
         for d in diffs:
-            tree_elements.append(InputGitTreeElement(
-                path=d.a_path,
-                mode=d.a_mode,
-                type=d.a_blob.type,
-                content="",
-                sha=d.a_blob.hexsha
-            ))
+            with open(d.a_path, "r") as f:
+                blob = self.__repo.create_git_blob(f.read(), "utf-8")
+                tree_elements.append(InputGitTreeElement(
+                    path=d.a_path,
+                    mode=d.a_mode,
+                    type='blob',
+                    sha=blob.sha
+                ))
             print(d.a_path)
         print("=======================================================================================================")
         # repo_dir

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -99,6 +99,7 @@ class GitHubProvider:
                     path=d.a_path,
                     mode='100644',
                     type='blob',
+                    content=blob.content,
                     sha=blob.sha
                 ))
             print(d.a_path)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -95,14 +95,15 @@ class GitHubProvider:
         for d in diffs:
             with open(d.a_path, "r") as f:
                 content = f.read()
+                print(content)
                 blob = self.__repo.create_git_blob(content, "utf-8")
                 tree_elements.append(InputGitTreeElement(
                     path=d.a_path,
                     mode='100644',
                     type='blob',
-                    content=content
+                    sha=blob.sha
                 ))
-            print(d.a_path)
+        print(tree_elements)
         print("=======================================================================================================")
         # repo_dir
 
@@ -113,7 +114,7 @@ class GitHubProvider:
             parents=[parent_commit]
         )
 
-        self.__repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=commit.sha)
+        self.__repo.create_git_ref(ref=f"heads/{branch_name}", sha=commit.sha)
 
         if not self.__config.dry_run:
             logging.info(f"Changes pushed to branch {branch_name}")

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -101,7 +101,7 @@ class GitHubProvider:
                 item = InputGitTreeElement(
                     path=d.a_path,
                     mode='100644',
-                    type='blob',
+                    type='commit',
                     content=content
                 )
                 tree_elements.append(item)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -95,7 +95,7 @@ class GitHubProvider:
                 path=d.a_path,
                 mode=d.a_mode,
                 type=d.a_blob.type,
-                content=d.a_blob.data_stream.read().decode('utf-8'),
+                content="",
                 sha=d.a_blob.hexsha
             ))
             print(d.a_path)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -82,11 +82,17 @@ class GitHubProvider:
 
         return set(branches)
 
-    def create_branch_and_push_all_changes(self, branch_name: str, commit_message: str):
+    def create_branch_and_push_all_changes(self, repo_dir, branch_name: str, commit_message: str):
         base_branch = self.__repo.get_branch(self.__repo.default_branch)
         base_tree = self.__repo.get_git_tree(base_branch.commit.sha)
 
-        self.__repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=base_branch.commit.sha)
+        repo = git.repo.Repo(repo_dir)
+        diff = repo.git.diff('HEAD')
+        print(diff)
+
+        # repo_dir
+
+        ref = self.__repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=base_branch.commit.sha)
 
         new_tree = self.__repo.create_git_tree([], base_tree.sha)
         commit = self.__repo.create_git_commit(

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -100,7 +100,7 @@ class GitHubProvider:
             with open(os.path.join(repo_dir, d.b_path), "r") as f:
                 content = f.read()
                 print("====================================")
-                print(str(oct(d.b_mode)))
+                print(str(oct(d.b_mode))[2:])
                 print("====================================")
                 item = InputGitTreeElement(
                     path=d.b_path,

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -95,7 +95,7 @@ class GitHubProvider:
                 blob = self.__repo.create_git_blob(f.read(), "utf-8")
                 tree_elements.append(InputGitTreeElement(
                     path=d.a_path,
-                    mode=d.a_mode,
+                    mode='100644',
                     type='blob',
                     sha=blob.sha
                 ))

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -93,7 +93,8 @@ class GitHubProvider:
         tree_elements = []
         print("=======================================================================================================")
         for d in diffs:
-            with open(d.a_path, "r") as f:
+            import os
+            with open(os.path.join(repo_dir, d.a_path), "r") as f:
                 content = f.read()
                 print(content)
                 item = InputGitTreeElement(

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -88,7 +88,7 @@ class GitHubProvider:
 
         parent_commit = self.__repo.get_git_commit(base_branch.commit.sha)
 
-        if not self.__config.dry_run:
+        if self.__config.dry_run:
             logging.info(f"Dry run: Changes pushed to branch {branch_name}")
             return
 

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -88,7 +88,7 @@ class GitHubProvider:
 
         parent_commit = self.__repo.get_git_commit(base_branch.commit.sha)
 
-        if self.__config.dry_run:
+        if not self.__config.dry_run:
             logging.info(f"Dry run: Changes pushed to branch {branch_name}")
             return
 

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -114,7 +114,7 @@ class GitHubProvider:
             parents=[parent_commit]
         )
 
-        self.__repo.create_git_ref(ref=f"heads/{branch_name}", sha=commit.sha)
+        self.__repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=commit.sha)
 
         if not self.__config.dry_run:
             logging.info(f"Changes pushed to branch {branch_name}")

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -88,8 +88,9 @@ class GitHubProvider:
 
         repo = git.repo.Repo(repo_dir)
         diff = repo.git.diff('HEAD')
+        print("=======================================================================================================")
         print(diff)
-
+        print("=======================================================================================================")
         # repo_dir
 
         ref = self.__repo.create_git_ref(ref=f"refs/heads/{branch_name}", sha=base_branch.commit.sha)

--- a/src/github_provider.py
+++ b/src/github_provider.py
@@ -95,6 +95,7 @@ class GitHubProvider:
         for d in diffs:
             with open(d.a_path, "r") as f:
                 content = f.read()
+                print(content)
                 item = InputGitTreeElement(
                     path=d.a_path,
                     mode='100644',

--- a/src/main.py
+++ b/src/main.py
@@ -69,11 +69,6 @@ def main(github_api_token: str, config: Config):
               show_default=True,
               default="affected_components.json",
               help="Path to output file that will contain list of affected components in json format")
-@click.option('--gpg-key-id',
-              required=False,
-              show_default=True,
-              default="",
-              help="GPG key ID to sign commits")
 @click.option('--pr-title-template',
               required=False,
               show_default=True,
@@ -101,7 +96,6 @@ def cli_main(github_api_token,
              log_level,
              dry_run,
              affected_components_file,
-             gpg_key_id,
              pr_title_template,
              pr_body_template,
              pr_labels):
@@ -119,7 +113,6 @@ def cli_main(github_api_token,
                     go_getter_tool,
                     dry_run,
                     affected_components_file,
-                    gpg_key_id,
                     pr_title_template,
                     pr_body_template,
                     pr_labels)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -26,7 +26,7 @@ pluggy==1.0.0
 pycodestyle==2.10.0
 pycparser==2.21
 pyflakes==3.0.1
-PyGithub==1.58.1
+PyGithub==2.5.0
 PyJWT==2.6.0
 pylint==2.17.1
 PyNaCl==1.5.0


### PR DESCRIPTION
## what

> [!CAUTION]
> This change has only undergone local development and has not been adequately tested for merge

- Removes GPG signing key option
- Updates commit signing to use `PyGitHub` instead of `GitPython` library

## why

- Commits are made using `GitPython`, while pull requests are handled with `PyGitHub`. I found that PyGitHub can also make commits, and it could leverage the Atmos App token to automatically sign them. Let me know if you'd be interested in testing this approach

## references

- [Commit Signing](https://github.com/nautilus-cyberneering/pygithub/blob/main/docs/how_to_sign_automatic_commits_in_github_actions.md)
- https://github.com/cloudposse/github-action-atmos-component-updater/pull/44