### PR TITLE
Fix atmos-version input and vendoring-disabled logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,3 +78,4 @@ runs:
     PR_LABELS: ${{ inputs.pr-labels }}
     PR_TITLE_TEMPLATE: ${{ inputs.pr-title-template }}
     PR_BODY_TEMPLATE: ${{ inputs.pr-body-template }}
+    ATMOS_VERSION: ${{ inputs.atmos-version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,13 @@ set -e
 
 export GO_GETTER_TOOL="/root/go/bin/go-getter"
 
+# Install the requested atmos version if specified
+if [ -n "$ATMOS_VERSION" ] && [ "$ATMOS_VERSION" != "latest" ]; then
+    echo "Installing atmos version ${ATMOS_VERSION}..."
+    apt-get update -qq > /dev/null 2>&1
+    apt-get install -y -qq atmos="${ATMOS_VERSION}-*" > /dev/null 2>&1
+fi
+
 cd /github/action/
 
 python3 src/main.py \

--- a/src/tools_manager.py
+++ b/src/tools_manager.py
@@ -34,6 +34,13 @@ class ToolsManager:
                 logging.error('Failed to delete {file_path}. Reason: {e}')
 
         os.environ['ATMOS_COMPONENTS_TERRAFORM_BASE_PATH'] = component.infra_terraform_dir
+        # Atmos requires stacks configuration even for vendoring.
+        # Set defaults so vendoring works without a full atmos.yaml.
+        for var, default in [('ATMOS_STACKS_BASE_PATH', 'stacks'),
+                             ('ATMOS_STACKS_INCLUDED_PATHS', 'orgs/**/*'),
+                             ('ATMOS_STACKS_NAME_PATTERN', '{tenant}-{environment}-{stage}')]:
+            if var not in os.environ:
+                os.environ[var] = default
         command = ["atmos", "vendor", "pull", "-c", component.name]
 
         logging.info(f"Executing '{' '.join(command)}' for component version '{component.version}' ... ")


### PR DESCRIPTION
## What

- Wire up the `atmos-version` input so it actually gets passed to the Docker container as `ATMOS_VERSION`
- Install the requested atmos version at runtime in the entrypoint when specified
- Set default stacks env vars (`ATMOS_STACKS_BASE_PATH`, `ATMOS_STACKS_INCLUDED_PATHS`, `ATMOS_STACKS_NAME_PATTERN`) for vendoring when not already set

## Why

The `atmos-version` input was defined in `action.yml` but never passed to the Docker container as an env var. The Dockerfile hardcodes atmos `1.34.2` which doesn't support `atmos vendor pull -c`. This caused the component updater to fail for any repo that requires a newer atmos version for vendoring.

Additionally, after PR #90 replaced the repo's `atmos.yaml` with a remote `import:` (which atmos 1.34.2 doesn't understand), `atmos vendor pull` started failing with missing stacks config errors. Setting sensible defaults for the required stacks env vars makes vendoring work without depending on a full `atmos.yaml` in the target repo.